### PR TITLE
Add debug tracing of requests

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 1.8.1-ome1
+version: 1.8.1-ome2
 appVersion: RELEASE.2018-09-12T18-49-56Z
 keywords:
 - storage

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ The following table lists the configurable parameters of the Minio chart and the
 | `nasgateway.enabled`       | Use minio as a [NAS gateway](https://docs.minio.io/docs/minio-gateway-for-nas)             | `false` |
 | `nasgateway.replicas`      | Number of NAS gateway instances to be run in parallel on a PV            | `4` |
 | `limitBandwidth.egress`   | Limit download speeds from minio, e.g. `1mbit`, default disabled    | `""`
+| `debug.http`   | Send HTTP trace logs to this file e.g. `/dev/stdout`, default disabled | `""`
+
 
 Some of the parameters above map to the env variables defined in the [Minio DockerHub image](https://hub.docker.com/r/minio/minio/).
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -102,6 +102,10 @@ spec:
                   name: {{ template "minio.fullname" . }}
                   key: gcs_key.json
             {{- end }}
+            {{- if .Values.debug.http }}
+            - name: MINIO_HTTP_TRACE
+              value: {{ .Values.debug.http }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /minio/health/live

--- a/values.yaml
+++ b/values.yaml
@@ -259,3 +259,6 @@ limitBandwidth:
   repository: minrk/tc-init
   tag: 0.0.4
   egress: ""
+
+debug:
+  http:


### PR DESCRIPTION
OMERO S3 parallel imports are failing with unexpected `Object not found` errors and occasional mentions of `io.minio.errors.InternalException: unhandled HTTP code 503`

As far as I can tell from the Minio server docs there are no standard logs, not even for errors. The only way I can find of getting error info out is to enable tracing of all HTTP requests, either to `/dev/stdout` which would be seen in the standard container logs, or to a file on disk.
- https://github.com/minio/minio/issues/6212
- https://github.com/minio/minio/issues/5134#issuecomment-344991120

Tag: `1.8.1-ome2`